### PR TITLE
Use schedule name as class name if unspecified

### DIFF
--- a/lib/active_scheduler/resque_wrapper.rb
+++ b/lib/active_scheduler/resque_wrapper.rb
@@ -23,7 +23,7 @@ module ActiveScheduler
           class:        'ActiveScheduler::ResqueWrapper',
           queue:        queue,
           args: [{
-            job_class:  opts[:class],
+            job_class:  opts[:class] || job,
             queue_name: queue,
             arguments:  opts[:arguments]
           }]

--- a/spec/active_scheduler/resque_wrapper_spec.rb
+++ b/spec/active_scheduler/resque_wrapper_spec.rb
@@ -66,6 +66,25 @@ describe ActiveScheduler::ResqueWrapper do
         expect(wrapped['no_queue_job']['queue']).to eq 'default'
       end
     end
+
+    context "when the schedule name is the class name" do
+      let(:schedule) { YAML.load_file 'spec/fixtures/schedule_name_is_class_name.yaml' }
+
+      it "queues up a job, using the schedule name for the class name" do
+        expect(wrapped['MyScheduleNameIsClassNameJob']).to eq(
+          "class"       => "ActiveScheduler::ResqueWrapper",
+          "queue"       => "myscheduledjobqueue",
+          "description" => "It's a self-named job.",
+          "cron"       => "* * * * *",
+          "args"        => [{
+            "job_class"  => "MyScheduleNameIsClassNameJob",
+            "queue_name" => "myscheduledjobqueue",
+            "arguments"  => nil
+          }]
+        )
+      end
+
+    end
   end
 
   describe ".perform" do

--- a/spec/fixtures/schedule_name_is_class_name.yaml
+++ b/spec/fixtures/schedule_name_is_class_name.yaml
@@ -1,0 +1,6 @@
+MyScheduleNameIsClassNameJob:
+  cron: "* * * * *"
+  queue: "myscheduledjobqueue"
+  args:
+    -
+  description: "It's a self-named job."


### PR DESCRIPTION
resque-scheduler will use the name of the scheduler as the job class name, if the name isn't specified in the 'class' attribute of the schedule.  This was not being supported in Active Scheduler.  The workaround is to simply specify the class name, but this change makes Active Scheduler that much more of a drop-in.