### PR TITLE
Only wrap jobs that inherit ActiveJob::Base

### DIFF
--- a/lib/active_scheduler/resque_wrapper.rb
+++ b/lib/active_scheduler/resque_wrapper.rb
@@ -15,7 +15,9 @@ module ActiveScheduler
       schedule = HashWithIndifferentAccess.new(schedule)
 
       schedule.each do |job, opts|
-        next if opts[:class] =~ /ActiveScheduler::ResqueWrapper/
+        class_name = opts[:class] || job
+        next if class_name =~ /ActiveScheduler::ResqueWrapper/
+        next unless class_name.constantize <= ActiveJob::Base
 
         queue = opts[:queue] || 'default'
 
@@ -23,7 +25,7 @@ module ActiveScheduler
           class:        'ActiveScheduler::ResqueWrapper',
           queue:        queue,
           args: [{
-            job_class:  opts[:class] || job,
+            job_class:  class_name,
             queue_name: queue,
             arguments:  opts[:arguments]
           }]

--- a/spec/active_scheduler/resque_wrapper_spec.rb
+++ b/spec/active_scheduler/resque_wrapper_spec.rb
@@ -9,6 +9,7 @@ describe ActiveScheduler::ResqueWrapper do
       let(:schedule) { YAML.load_file 'spec/fixtures/simple_job.yaml' }
 
       it "queues up a simple job" do
+        stub_jobs("SimpleJob")
         expect(wrapped['simple_job']).to eq(
           "class"       => "ActiveScheduler::ResqueWrapper",
           "queue"       => "simple",
@@ -21,12 +22,26 @@ describe ActiveScheduler::ResqueWrapper do
           }]
         )
       end
+
+      context "job is not an active job descendant" do
+        it "doesn't wrap" do
+          stub_const("SimpleJob", Class.new)
+          expect(wrapped['simple_job']).to eq(
+            "class"       => "SimpleJob",
+            "queue"       => "simple",
+            "description" => "It's a simple job.",
+            "every"       => "30s",
+            "args"        => [nil],
+          )
+        end
+      end
     end
 
     context "with a simple job json" do
       let(:schedule) { YAML.load_file 'spec/fixtures/simple_job.json' }
 
       it "queues up a simple job" do
+        stub_jobs("SimpleJob")
         expect(wrapped['simple_job']).to eq(
           "class"       => "ActiveScheduler::ResqueWrapper",
           "queue"       => "simple",
@@ -45,6 +60,7 @@ describe ActiveScheduler::ResqueWrapper do
       let(:schedule) { YAML.load_file 'spec/fixtures/two_jobs.yaml' }
 
       it "queues them all up simple job" do
+        stub_jobs("JobOne", "JobTwo")
         expect(wrapped['job_1']['args'][0]['job_class']).to eq 'JobOne'
         expect(wrapped['job_2']['args'][0]['job_class']).to eq 'JobTwo'
       end
@@ -54,6 +70,7 @@ describe ActiveScheduler::ResqueWrapper do
       let(:schedule) { YAML.load_file 'spec/fixtures/cron_job.yaml' }
 
       it "uses that instead" do
+        stub_jobs("CronJob")
         expect(wrapped['cron_job']['cron']).to eq '* * * *'
         expect(wrapped['cron_job']['every']).to be_nil
       end
@@ -63,6 +80,7 @@ describe ActiveScheduler::ResqueWrapper do
       let(:schedule) { YAML.load_file 'spec/fixtures/no_queue.yaml' }
 
       it "uses 'default'" do
+        stub_jobs("SimpleJob")
         expect(wrapped['no_queue_job']['queue']).to eq 'default'
       end
     end
@@ -71,6 +89,7 @@ describe ActiveScheduler::ResqueWrapper do
       let(:schedule) { YAML.load_file 'spec/fixtures/schedule_name_is_class_name.yaml' }
 
       it "queues up a job, using the schedule name for the class name" do
+        stub_jobs("MyScheduleNameIsClassNameJob")
         expect(wrapped['MyScheduleNameIsClassNameJob']).to eq(
           "class"       => "ActiveScheduler::ResqueWrapper",
           "queue"       => "myscheduledjobqueue",
@@ -83,7 +102,6 @@ describe ActiveScheduler::ResqueWrapper do
           }]
         )
       end
-
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,7 +5,16 @@ unless ENV["NO_COVERALLS"]
   Coveralls.wear!
 end
 
+module Helpers
+  def stub_jobs(*names)
+    names.each do |name|
+      stub_const(name, Class.new(ActiveJob::Base))
+    end
+  end
+end
+
 RSpec.configure do |config|
+  config.include Helpers
   config.filter_run :focus
   config.run_all_when_everything_filtered = true
 end


### PR DESCRIPTION
Hi,

We have a lot of jobs in our resque schedule that are not `ActiveJob::Base` descendants, just plain old resque jobs pre-dating active job.
We want to support activejobs moving forward in our resque schedule, but are not interested to update the existing jobs.

This changes active_scheduler to not assume every job in the schedule is an active job, at the marginal expense of looking up class objects (`.constantize`) when wrapping the config, which is fine for us.