### PR TITLE
Deprecate arguments key in schedule

### DIFF
--- a/lib/active_scheduler/resque_wrapper.rb
+++ b/lib/active_scheduler/resque_wrapper.rb
@@ -20,6 +20,14 @@ module ActiveScheduler
         next unless class_name.constantize <= ActiveJob::Base
 
         queue = opts[:queue] || 'default'
+        args = opts[:args]
+
+        if !args && opts.has_key?(:arguments)
+          warn 'active_scheduler: [DEPRECATION] using the `arguments` key in ' \
+            'your resque schedule will soon be deprecated. Please revert to ' \
+            'the resque standard `args` key.'
+          args = opts[:arguments]
+        end
 
         schedule[job] = {
           class:        'ActiveScheduler::ResqueWrapper',
@@ -27,7 +35,7 @@ module ActiveScheduler
           args: [{
             job_class:  class_name,
             queue_name: queue,
-            arguments:  opts[:arguments]
+            arguments:  args
           }]
         }
 

--- a/spec/active_scheduler/resque_wrapper_spec.rb
+++ b/spec/active_scheduler/resque_wrapper_spec.rb
@@ -18,7 +18,7 @@ describe ActiveScheduler::ResqueWrapper do
           "args"        => [{
             "job_class"  => "SimpleJob",
             "queue_name" => "simple",
-            "arguments"  => nil
+            "arguments"  => ['foo-arg-1', 'foo-arg-2'],
           }]
         )
       end
@@ -31,7 +31,7 @@ describe ActiveScheduler::ResqueWrapper do
             "queue"       => "simple",
             "description" => "It's a simple job.",
             "every"       => "30s",
-            "args"        => [nil],
+            "args"        => ['foo-arg-1', 'foo-arg-2'],
           )
         end
       end
@@ -50,7 +50,7 @@ describe ActiveScheduler::ResqueWrapper do
           "args"        => [{
             "job_class"  => "SimpleJob",
             "queue_name" => "simple",
-            "arguments"  => nil
+            "arguments"  => "foo-argument",
           }]
         )
       end
@@ -98,7 +98,7 @@ describe ActiveScheduler::ResqueWrapper do
           "args"        => [{
             "job_class"  => "MyScheduleNameIsClassNameJob",
             "queue_name" => "myscheduledjobqueue",
-            "arguments"  => nil
+            "arguments"  => [nil]
           }]
         )
       end

--- a/spec/fixtures/simple_job.json
+++ b/spec/fixtures/simple_job.json
@@ -3,6 +3,7 @@
     "every": "30s",
     "queue": "simple",
     "class": "SimpleJob",
-    "description": "It's a simple job."
+    "description": "It's a simple job.",
+    "arguments": "foo-argument"
   }
 }

--- a/spec/fixtures/simple_job.yaml
+++ b/spec/fixtures/simple_job.yaml
@@ -3,5 +3,6 @@ simple_job:
   queue: "simple"
   class: "SimpleJob"
   args:
-    -
+    - foo-arg-1
+    - foo-arg-2
   description: "It's a simple job."


### PR DESCRIPTION
hi,

Using a special key to pass arguments from the schedule to a job, different from the standard key used in resque-scheduler, seems like an unnecessary cognitive load on users of this gem.

This PR reverts to use the resque-scheduler stardard `args` key rather than the current `arguments` key.