### PR TITLE
Queue defaults to the job's queue

### DIFF
--- a/lib/active_scheduler/resque_wrapper.rb
+++ b/lib/active_scheduler/resque_wrapper.rb
@@ -24,9 +24,11 @@ module ActiveScheduler
       schedule.each do |job, opts|
         class_name = opts[:class] || job
         next if class_name =~ /ActiveScheduler::ResqueWrapper/
-        next unless class_name.constantize <= ActiveJob::Base
+        
+        klass = class_name.constantize
+        next unless klass <= ActiveJob::Base
 
-        queue = opts[:queue] || 'default'
+        queue = opts[:queue] || klass.queue_name
         args = opts[:args]
         named_args = opts[:named_args] || false
 

--- a/spec/active_scheduler/resque_wrapper_spec.rb
+++ b/spec/active_scheduler/resque_wrapper_spec.rb
@@ -79,9 +79,14 @@ describe ActiveScheduler::ResqueWrapper do
     context "when the queue is blank" do
       let(:schedule) { YAML.load_file 'spec/fixtures/no_queue.yaml' }
 
-      it "uses 'default'" do
-        stub_jobs("SimpleJob")
-        expect(wrapped['no_queue_job']['queue']).to eq 'default'
+      it "uses the job's queue" do
+        simple_job = Class.new(ActiveJob::Base) do
+          queue_as :myscheduledjobqueue
+        end
+        
+        stub_const("SimpleJob", simple_job)
+        
+        expect(wrapped['no_queue_job']['queue']).to eq 'myscheduledjobqueue'
       end
     end
 


### PR DESCRIPTION
When the queue for a given job is not specified in the schedule file, the
default value should be taken for the job itself (eg `queue_as :foo`)
instead of always be `default`.

(Especially since `default` is already the default queue set by ActiveJob::Base)