### PR TITLE
Implement ActiveScheduler::ResqueWrapper.scheduled

### DIFF
--- a/lib/active_scheduler/resque_wrapper.rb
+++ b/lib/active_scheduler/resque_wrapper.rb
@@ -18,6 +18,10 @@ module ActiveScheduler
       end
     end
 
+    def self.scheduled(_queue, _wrapper_klass, *args)
+      perform(*args)
+    end
+
     def self.wrap(schedule)
       schedule = HashWithIndifferentAccess.new(schedule)
 

--- a/spec/active_scheduler/resque_wrapper_spec.rb
+++ b/spec/active_scheduler/resque_wrapper_spec.rb
@@ -210,4 +210,21 @@ describe ActiveScheduler::ResqueWrapper do
       end
     end
   end
+
+  describe '.scheduled' do
+    let(:queue_name) { 'test_queue' }
+    let(:job_data) { {'job_class' => 'TestKlass'} }
+
+    before do
+      allow(described_class).to receive(:perform)
+    end
+
+    after do
+      described_class.scheduled(queue_name, described_class, job_data)
+    end
+
+    it 'delegates to .perform with job_data' do
+      expect(described_class).to receive(:perform).with(job_data)
+    end
+  end
 end


### PR DESCRIPTION
Add support for ActiveJob/Resque callbacks when scheduling jobs
by implementing ResqueWrapper.scheduled as described in:

https://github.com/resque/resque-scheduler/tree/402cd06189c2d2abacc0c530dadd5db5ad46c268#support-for-resque-status-and-other-custom-jobs

Without this method, resque-scheduler will enqueue the job
using Resque::Job.create, bypassing callbacks entirely, see:

https://github.com/resque/resque-scheduler/blob/402cd06189c2d2abacc0c530dadd5db5ad46c268/lib/resque/scheduler.rb#L257