### PR TITLE
Remove deprecated Rubyforge reference.

### DIFF
--- a/active_scheduler.gemspec
+++ b/active_scheduler.gemspec
@@ -12,8 +12,6 @@ Gem::Specification.new do |s|
   s.summary     = %q{Scheduling for ActiveJob}
   s.description = %q{A wrapper for scheduling jobs through ActiveJob}
 
-  s.rubyforge_project = "active_scheduler"
-
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {spec}/*`.split("\n")
   s.require_paths = ["lib"]


### PR DESCRIPTION
Rubyforge is no more, and Rubygems 3 complains about it now with `NOTE: Gem::Specification#rubyforge_project= is deprecated with no replacement. It will be removed on or after 2019-12-01.`

This just axes the reference.