### PR TITLE
Add ActiveScheduler.config.{guard_with,queue_name_resolver}

### DIFF
--- a/lib/active_scheduler.rb
+++ b/lib/active_scheduler.rb
@@ -3,5 +3,21 @@ require 'active_scheduler/version'
 require 'active_scheduler/resque_wrapper'
 
 module ActiveScheduler
+  Config = Struct.new(:guard_with, :queue_name_resolver)
 
+  class << self
+    def config
+      @config ||= Config.new
+    end
+
+    def configure(&block)
+      yield(config)
+    end
+  end
+
+  # Default config
+  configure do |config|
+    config.guard_with = ->(class_name) { class_name.constantize <= ActiveJob::Base }
+    config.queue_name_resolver = ->(class_name) { class_name.constantize.queue_name }
+  end
 end

--- a/lib/active_scheduler/resque_wrapper.rb
+++ b/lib/active_scheduler/resque_wrapper.rb
@@ -28,11 +28,9 @@ module ActiveScheduler
       schedule.each do |job, opts|
         class_name = opts[:class] || job
         next if class_name =~ /#{self.to_s}/
+        next unless ActiveScheduler.config.guard_with.(class_name)
 
-        klass = class_name.constantize
-        next unless klass <= ActiveJob::Base
-
-        queue = opts[:queue] || klass.queue_name
+        queue = opts[:queue] || ActiveScheduler.config.queue_name_resolver.(class_name)
         args = opts[:args]
         named_args = opts[:named_args] || false
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,9 +6,9 @@ unless ENV["NO_COVERALLS"]
 end
 
 module Helpers
-  def stub_jobs(*names)
+  def stub_jobs(*names, base_class: ActiveJob::Base)
     names.each do |name|
-      stub_const(name, Class.new(ActiveJob::Base))
+      stub_const(name, Class.new(base_class))
     end
   end
 end


### PR DESCRIPTION
This allows configuration of a custom guard clause to check whether jobs should be wrapped or not, as well as allowing for a custom `queue_name_resolver` configuration which will be called to resolve the queue name when the queue is not configured. The idea behind this is to enable an option which avoids the use of `class_name.constantize`, meaning that we don't have to load the entire Rails environment for the resque scheduler rake task and save some memory.

Alternative to #22