### PR TITLE
Add ActiveScheduler.config.check_jobs_descend_from_active_job

### DIFF
--- a/lib/active_scheduler.rb
+++ b/lib/active_scheduler.rb
@@ -1,7 +1,23 @@
 require 'active_job'
+require 'active_scheduler/errors'
 require 'active_scheduler/version'
 require 'active_scheduler/resque_wrapper'
 
 module ActiveScheduler
+  Config = Struct.new(:check_jobs_descend_from_active_job)
 
+  class << self
+    def config
+      @config ||= Config.new
+    end
+
+    def configure(&block)
+      yield(config)
+    end
+  end
+
+  # Default config
+  configure do |config|
+    config.check_jobs_descend_from_active_job = true
+  end
 end

--- a/lib/active_scheduler/errors.rb
+++ b/lib/active_scheduler/errors.rb
@@ -1,0 +1,4 @@
+module ActiveScheduler
+  Error = Class.new(StandardError)
+  QueueConfigMissingError = Class.new(Error)
+end

--- a/lib/active_scheduler/resque_wrapper.rb
+++ b/lib/active_scheduler/resque_wrapper.rb
@@ -29,10 +29,14 @@ module ActiveScheduler
         class_name = opts[:class] || job
         next if class_name =~ /#{self.to_s}/
 
-        klass = class_name.constantize
-        next unless klass <= ActiveJob::Base
+        if ActiveScheduler.config.check_jobs_descend_from_active_job
+          klass = class_name.constantize
+          next unless klass <= ActiveJob::Base
+          queue = opts[:queue] || klass.queue_name
+        else
+          queue = opts.fetch(:queue) { raise QueueConfigMissingError, "no queue configured for #{class_name}" }
+        end
 
-        queue = opts[:queue] || klass.queue_name
         args = opts[:args]
         named_args = opts[:named_args] || false
 

--- a/spec/active_scheduler/resque_wrapper_spec.rb
+++ b/spec/active_scheduler/resque_wrapper_spec.rb
@@ -25,16 +25,48 @@ describe ActiveScheduler::ResqueWrapper do
       end
 
       context "job is not an active job descendant" do
-        it "doesn't wrap" do
-          stub_const("SimpleJob", Class.new)
-          expect(wrapped['simple_job']).to eq(
-            "class"       => "SimpleJob",
-            "queue"       => "simple",
-            "description" => "It's a simple job.",
-            "every"       => "30s",
-            "rails_env"   => "test",
-            "args"        => ['foo-arg-1', 'foo-arg-2'],
-          )
+        context "with default config" do
+          it "doesn't wrap" do
+            stub_jobs("SimpleJob", base_class: Class.new)
+            expect(wrapped['simple_job']).to eq(
+              "class"       => "SimpleJob",
+              "queue"       => "simple",
+              "description" => "It's a simple job.",
+              "every"       => "30s",
+              "rails_env"   => "test",
+              "args"        => ['foo-arg-1', 'foo-arg-2'],
+            )
+          end
+        end
+
+        context "with check_jobs_descend_from_active_job configured to false" do
+          let!(:check_jobs_descend_from_active_job) do
+            ActiveScheduler.config.check_jobs_descend_from_active_job
+          end
+
+          before do
+            ActiveScheduler.config.check_jobs_descend_from_active_job = false
+          end
+
+          after do
+            ActiveScheduler.config.check_jobs_descend_from_active_job = check_jobs_descend_from_active_job
+          end
+
+          it "wraps the job" do
+            stub_jobs("SimpleJob", base_class: Class.new)
+            expect(wrapped['simple_job']).to eq(
+              "class"       => "ActiveScheduler::ResqueWrapper",
+              "queue"       => "simple",
+              "description" => "It's a simple job.",
+              "every"       => "30s",
+              "rails_env"   => "test",
+              "args"        => [{
+                "job_class"  => "SimpleJob",
+                "queue_name" => "simple",
+                "arguments"  => ['foo-arg-1', 'foo-arg-2'],
+              }]
+            )
+          end
         end
       end
 
@@ -125,14 +157,38 @@ describe ActiveScheduler::ResqueWrapper do
     context "when the queue is blank" do
       let(:schedule) { YAML.load_file 'spec/fixtures/no_queue.yaml' }
 
-      it "uses the job's queue" do
-        simple_job = Class.new(ActiveJob::Base) do
-          queue_as :myscheduledjobqueue
+      context "with default config" do
+        it "uses the job's queue" do
+          simple_job = Class.new(ActiveJob::Base) do
+            queue_as :myscheduledjobqueue
+          end
+
+          stub_const("SimpleJob", simple_job)
+
+          expect(wrapped['no_queue_job']['queue']).to eq 'myscheduledjobqueue'
+        end
+      end
+
+      context "with check_jobs_descend_from_active_job configured to false" do
+        let!(:check_jobs_descend_from_active_job) do
+          ActiveScheduler.config.check_jobs_descend_from_active_job
         end
 
-        stub_const("SimpleJob", simple_job)
+        before do
+          ActiveScheduler.config.check_jobs_descend_from_active_job = false
+        end
 
-        expect(wrapped['no_queue_job']['queue']).to eq 'myscheduledjobqueue'
+        after do
+          ActiveScheduler.config.check_jobs_descend_from_active_job = check_jobs_descend_from_active_job
+        end
+
+        it "raises ActiveScheduler::QueueConfigMissingError" do
+          simple_job = Class.new
+
+          stub_const("SimpleJob", simple_job)
+
+          expect { wrapped }.to raise_error(ActiveScheduler::QueueConfigMissingError)
+        end
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,9 +6,9 @@ unless ENV["NO_COVERALLS"]
 end
 
 module Helpers
-  def stub_jobs(*names)
+  def stub_jobs(*names, base_class: ActiveJob::Base)
     names.each do |name|
-      stub_const(name, Class.new(ActiveJob::Base))
+      stub_const(name, Class.new(base_class))
     end
   end
 end


### PR DESCRIPTION
When set to false, this will skip the check in `ActiveScheduler::ResqueWrapper.wrap` which checks whether the job class descends from `ActiveJob::Base`, this means that we no longer need to call `class_name.constantize`, which should mean that we can skip loading the whole Rails environment for the resque scheduler rake task and save some memory.