### PR TITLE
Add support for ActiveJobWrapper

### DIFF
--- a/lib/active_scheduler/resque_wrapper.rb
+++ b/lib/active_scheduler/resque_wrapper.rb
@@ -30,7 +30,11 @@ module ActiveScheduler
         next if class_name =~ /#{self.to_s}/
 
         klass = class_name.constantize
-        next unless klass <= ActiveJob::Base
+        active_job_wrapper = defined?(ActiveJobWrapper) && klass.ancestors.include?(ActiveJobWrapper)
+
+        next unless klass <= ActiveJob::Base || active_job_wrapper
+
+        klass = klass::Job if active_job_wrapper
 
         queue = opts[:queue] || klass.queue_name
         args = opts[:args]
@@ -47,7 +51,7 @@ module ActiveScheduler
           class:        self.to_s,
           queue:        queue,
           args: [{
-                   job_class:  class_name,
+                   job_class:  klass.to_s,
                    queue_name: queue,
                    arguments:  args,
                  }]


### PR DESCRIPTION
The original implementation didn't work with our wrapped jobs. They'd have still be enqueued the legacy way. Which means we'd have still had a large number of jobs on the queue using the wrong class name. Somewhat defeating the purpose of what we were doing in the first place. 

Adjusting the implementation so that if the wrapper is defined and being used within the respective class, it mutates the class reference within the job arguments to be the `::Job` constant variant. 

Else, it just wraps it as expected.

Or it skips it, if it's using neither the wrapper nor inherits from ActiveJob.